### PR TITLE
WIP: Data Model and Input Module for flsimulate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ include(externals/gitconddb.cmake)
 # Find other needed packages
 find_package(art 3 REQUIRED)
 find_package(canvas_root_io REQUIRED)
+find_package(art_root_io REQUIRED)
 find_package(ROOT REQUIRED)
 
 # Set them up...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,13 @@ cet_set_compiler_flags(
 include(externals/bayeux.cmake)
 include(externals/gitconddb.cmake)
 
+# Find other needed packages
+find_package(art 3 REQUIRED)
+find_package(canvas_root_io REQUIRED)
+
+# Set them up...
+include(ArtDictionary)
+
 # SNemo
 add_subdirectory(snemo)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,11 @@ include(externals/gitconddb.cmake)
 # Find other needed packages
 find_package(art 3 REQUIRED)
 find_package(canvas_root_io REQUIRED)
+find_package(ROOT REQUIRED)
 
 # Set them up...
 include(ArtDictionary)
+include(BuildPlugins)
 
 # SNemo
 add_subdirectory(snemo)

--- a/doc/ImpressionistArt.md
+++ b/doc/ImpressionistArt.md
@@ -1,0 +1,211 @@
+Impressionist: Art for SuperNEMO
+================================
+
+Impressionist is a prototype of an Art-based data model and event data
+processing system for SuperNEMO. In most cases, it simply provides a bridge
+between the existing Falaise/Bayeux file formats, data models, and services
+to their equivalents in Art.
+
+The sections below describe the main use cases with basic demonstrations
+
+
+Reading Falaise/FLSimulate Output Data into Art
+===============================================
+Read BRIO format data as output by [Falaise's flsimulate](https://supernemo.org/Falaise/usingflsimulate.html)
+application into Art, reconstituting equivalent of "SD" data bank.
+Implementation involves two pieces of code:
+
+1. A C++ library providing the interface to the data products and
+   a ROOT dictionary to enable serialization
+2. An [Art Source Module](https://cdcvs.fnal.gov/redmine/projects/art/wiki/Writing_your_own_input_sources)
+   to read flsimulate BRIO file and reconstitute data products into Art
+
+Implementation details on these elements are available in [snemo/edm/README.md](../snemo/edm/README.md).
+
+As we did for Art's own modules, we can get information about the
+source module, `BrioInput`, from the command line:
+
+```console
+$ art --print-description BrioInput
+====================================================================================================
+
+    module_type: BrioInput (or "snemo/edm/BrioInput")
+
+    provider: user
+    source  : <system_specific>/Impressionist.git/snemo/edm/BrioInput_source.cc
+    library : <system_specific>/Impressionist.build/lib/libsnemo_edm_BrioInput_source.so
+
+    Allowed configuration
+    ---------------------
+
+    [ None provided ]
+
+====================================================================================================
+
+$
+```
+
+Since it's a very simple single file ready, it doesn't take any specialized configuration.
+
+To use it to read an output file from `flsimulate`, `BrioInput` needs to be declared
+as the `module_type` under `source` section of your art FHiCL script. using the info
+printed above, we can write this as:
+
+```
+source: {
+  module_type: BrioInput
+}
+```
+
+or using the fully qualified name:
+
+```
+source: {
+  module_type: "snemo/edm/BrioInput"
+}
+```
+
+Note the quotes are needed for the fully qualified name! Write one of the above
+to `brioinput_t.fcl` and run it in `art` using the `-s` flag to point to an `flsimulate`
+output file:
+
+```
+$ art -s /my/flsimulate/file.brio -c brioinput_t.fcl
+INFO: using default process_name of "DUMMY".
+%MSG-i MF_INIT_OK:  Early 20-Jun-2019 16:14:36 BST JobSetup
+Messagelogger initialization complete.
+%MSG
+Opening file /my/flsimulate/file.brio
+New run
+
+TrigReport ---------- Event  Summary ------------
+TrigReport Events total = 100 passed = 100 failed = 0
+
+TimeReport ---------- Time  Summary ---[sec]----
+TimeReport CPU = 1.217760 Real = 1.576359
+
+MemReport  ---------- Memory  Summary ---[base-10 MB]----
+MemReport  VmPeak = 683.262 VmHWM = 218.96
+
+Art has completed and will exit with status 0.
+$
+```
+
+The number of events and timings will of course vary depending on your
+file and system. To see that `art` is actually doing something, we can
+use the `FileDumperOutput` output module to log information about the
+data products. Change your `brioinput_t.fcl` file as follows:
+
+```
+source: {
+  module_type: "BrioInput"
+}
+
+# Must have a path to output
+physics: {
+  outputPath: [ fileDumper ]
+}
+
+outputs: {
+  fileDumper: {
+    module_type: FileDumperOutput
+  }
+}
+```
+
+Rerun with your input file, and you should see much more output:
+
+```console
+$ art -s /my/flsimulate/file.brio -c brioinput_t.fcl
+INFO: using default process_name of "DUMMY".
+%MSG-i MF_INIT_OK:  Early 20-Jun-2019 16:24:03 BST JobSetup
+Messagelogger initialization complete.
+%MSG
+Opening file /my/flsimulate/file.brio
+New run
+PRINCIPAL TYPE: Event
+PROCESS NAME | MODULE LABEL | PRODUCT INSTANCE NAME | DATA PRODUCT TYPE.............. | PRODUCT FRIENDLY TYPE... | SIZE
+DUMMY....... | SD.......... | gg................... | std::vector<snemo::BaseStepHit> | snemo::BaseStepHits..... | ..13
+DUMMY....... | SD.......... | calo................. | std::vector<snemo::BaseStepHit> | snemo::BaseStepHits..... | ...1
+DUMMY....... | SD.......... | gveto................ | std::vector<snemo::BaseStepHit> | snemo::BaseStepHits..... | ...0
+DUMMY....... | SD.......... | ..................... | double......................... | double.................. | ...-
+DUMMY....... | SD.......... | xcalo................ | std::vector<snemo::BaseStepHit> | snemo::BaseStepHits..... | ...0
+DUMMY....... | SD.......... | ..................... | CLHEP::Hep3Vector.............. | CLHEP::Hep3Vector....... | ...-
+DUMMY....... | SD.......... | ..................... | snemo::GenBBPrimaryEvent....... | snemo::GenBBPrimaryEvent | ...-
+
+Total products (present, not present): 7 (7, 0).
+
+...
+
+PRINCIPAL TYPE: Event
+PROCESS NAME | MODULE LABEL | PRODUCT INSTANCE NAME | DATA PRODUCT TYPE.............. | PRODUCT FRIENDLY TYPE... | SIZE
+DUMMY....... | SD.......... | gg................... | std::vector<snemo::BaseStepHit> | snemo::BaseStepHits..... | ..39
+DUMMY....... | SD.......... | calo................. | std::vector<snemo::BaseStepHit> | snemo::BaseStepHits..... | ...1
+DUMMY....... | SD.......... | gveto................ | std::vector<snemo::BaseStepHit> | snemo::BaseStepHits..... | ...0
+DUMMY....... | SD.......... | ..................... | double......................... | double.................. | ...-
+DUMMY....... | SD.......... | xcalo................ | std::vector<snemo::BaseStepHit> | snemo::BaseStepHits..... | ...0
+DUMMY....... | SD.......... | ..................... | CLHEP::Hep3Vector.............. | CLHEP::Hep3Vector....... | ...-
+DUMMY....... | SD.......... | ..................... | snemo::GenBBPrimaryEvent....... | snemo::GenBBPrimaryEvent | ...-
+
+Total products (present, not present): 7 (7, 0).
+
+PRINCIPAL TYPE: Run
+PROCESS NAME | MODULE LABEL | PRODUCT INSTANCE NAME | DATA PRODUCT TYPE..... | PRODUCT FRIENDLY TYPE. | SIZE
+DUMMY....... | SD.......... | ..................... | snemo::MultiProperties | snemo::MultiProperties | ...-
+
+Total products (present, not present): 1 (1, 0).
+
+
+TrigReport ---------- Event  Summary ------------
+TrigReport Events total = 100 passed = 100 failed = 0
+
+TrigReport ------ Modules in End-Path: end_path ------------
+TrigReport  Trig Bit#        Run    Success      Error Name
+TrigReport     0    0        100        100          0 fileDumper
+
+TimeReport ---------- Time  Summary ---[sec]----
+TimeReport CPU = 1.280318 Real = 1.531156
+
+MemReport  ---------- Memory  Summary ---[base-10 MB]----
+MemReport  VmPeak = 686.055 VmHWM = 219.722
+
+Art has completed and will exit with status 0.
+$
+```
+
+Again, your output will differ depending on your system and file, but you
+should see that we have 7 data products in each Event, plus one in the Run.
+
+Finally, you can "convert" the BRIO files to Art's native ROOT format using
+the FHiCL script:
+
+```
+source: {
+  module_type: BrioInput
+}
+```
+
+and running it as:
+
+```console
+$ art -s /my/flsimulate/file.brio -c brioinput_t.fcl -o file.art
+...
+```
+
+The resultant Art/ROOT file can be queried using several helper
+programs provided by the `art_root_io` package:
+
+- `config_dumper`: this program will read an art/ROOT output file and print out configuration information for the process(es) that created that file.
+- `file_info_dumper`: this program will read an art/ROOT output file and has the ability to print the list of events in the file, print the range of events, subruns, and runs that contributed to making the file, and provides access to the internal SQLite database, which can be saved to an external database.
+- `count_events`: this program will read an art/ROOT output file and print out how many events are contained in that file.
+- `product_sizes_dumper`: this program will read and art/ROOT output file and print out information about the sizes of products.
+- `sam_metadata_dumper`: The sam_metadata_dumper application will read an art-ROOT format file, and extract the information for possible post-processing and upload to SAM.
+
+See the [art suite programs](https://cdcvs.fnal.gov/redmine/projects/art/wiki) section of the art Wiki
+for more information on these.
+
+
+Accessing FLSimulate Data Products in Art Modules
+=================================================
+Next...
+

--- a/doc/README.md
+++ b/doc/README.md
@@ -14,10 +14,10 @@ it provides many features **not** supported by _Falaise_, namely:
 The primary point of contact for users is the `art` executable which, like
 `flreconstruct`, is run by supplying input/output source(s)/sink(s) for
 data together which a script defining the workflow to be performed on that
-data. 
+data.
 
-Though the sections below are a largely self-contained introduction to _art_, they 
-should be consulted together with the main _art_ framework and scripting 
+Though the sections below are a largely self-contained introduction to _art_, they
+should be consulted together with the main _art_ framework and scripting
 documentation available at:
 
 - [Overall Art Guide](https://cdcvs.fnal.gov/redmine/projects/art/wiki)
@@ -41,7 +41,7 @@ art 3.02.04
 $
 ```
 
-If `art <VERSIONNUMBER>` is printed, you're good to go. If there are any issues here, 
+If `art <VERSIONNUMBER>` is printed, you're good to go. If there are any issues here,
 please raise an [Issue](https://github.com/SuperNEMO-DBD/Impressionist/issues)
 or drop @drbenmorgan a mail.
 
@@ -78,7 +78,7 @@ in the pipeline script.
 Just like Falaise, Art's functionality is implemented as a pipeline whose input,
 processing, and output are controlled through a sequence of modules defined by
 the FHiCL script. Art also implements the concept of "Services" that provide information
-that is not strictly Event or Run level (for example, logging, profiling). These too 
+that is not strictly Event or Run level (for example, logging, profiling). These too
 can be configured by the FHiCL script.
 
 Getting Help on Modules and Services
@@ -93,7 +93,7 @@ including those for SuperNEMO, by using the `--print-available <type>` argument.
 - `module`: A module that handles processing of event data.
 - `service`: A service living outside the pipeline and which may be accessed
   by `source` and `module` modules.
-  
+
 As of `art` 3.2.4, each of these prints the following:
 
 ```console
@@ -144,7 +144,7 @@ $
 ```
 
 We'll see in the coming sections how to use these in a pipeline script. Art's
-scripting system provides descriptions and help on the configuration parameters 
+scripting system provides descriptions and help on the configuration parameters
 available or required by a given module or service. For example, one of the first modules we'll
 use is the `EmptyEvent` source module, and we can see how to configure this
 using:
@@ -195,12 +195,12 @@ $ art --print-description EmptyEvent
 
            ## The 'timestampPlugin' parameter must be a FHiCL table
            ## of the form:
-           ## 
+           ##
            ##   timestampPlugin: {
            ##     plugin_type: <plugin specification>
            ##     ...
            ##   }
-           ## 
+           ##
            ## See the notes in art/Framework/Core/EmptyEventTimestampPlugin.h
            ## for more details.
 
@@ -239,7 +239,7 @@ Checking the output of `art --help`, we can see that to pass a script to `art` v
 
 ```console
 $ art -c examples/zero.fcl
-INFO: provided configuration file 'examples/zero.fcl' is empty: 
+INFO: provided configuration file 'examples/zero.fcl' is empty:
 using minimal defaults and command-line options.
 INFO: using default process_name of "DUMMY".
 %MSG-i MF_INIT_OK:  Early 21-May-2019 15:33:59 BST JobSetup
@@ -271,9 +271,9 @@ Art will search for the script we supply using the following rules:
     - The first existing matched file being used, or
     - Execution will be stopped if no existing matched file is found
 
-The reason that suppliying `examples/zero.fcl` as a relative path works is that is has been found through searching 
+The reason that suppliying `examples/zero.fcl` as a relative path works is that is has been found through searching
 `FHICL_FILE_PATH`. Impressionist sets this as part of its `setup_for_development` script so that running during the
-compile/test cycle uses an FHiCL scripts supplied by the project.  As we'll see later, the use of `FHICL_FILE_PATH` 
+compile/test cycle uses an FHiCL scripts supplied by the project.  As we'll see later, the use of `FHICL_FILE_PATH`
 also enables the _composability_ of FHiCL scripts by providing a C++ header like lookup.
 
 
@@ -403,12 +403,12 @@ $ art --print-description EmptyEvent
 
            ## The 'timestampPlugin' parameter must be a FHiCL table
            ## of the form:
-           ## 
+           ##
            ##   timestampPlugin: {
            ##     plugin_type: <plugin specification>
            ##     ...
            ##   }
-           ## 
+           ##
            ## See the notes in art/Framework/Core/EmptyEventTimestampPlugin.h
            ## for more details.
 
@@ -465,7 +465,7 @@ $
 You can still pass the `-n` command line argument to override the number of events.
 
 Part of the FHiCL validation system is helpful error messaging. For example,
-if we spell the name of a parameter incorrectly as in [fcl/examples/second_error.fcl](../fcl/examples/second_error.fcl), 
+if we spell the name of a parameter incorrectly as in [fcl/examples/second_error.fcl](../fcl/examples/second_error.fcl),
 `art` will point to the location and cause of the error:
 
 ``` console
@@ -477,16 +477,16 @@ Messagelogger initialization complete.
 %MSG-s ArtException:  Early 21-May-2019 16:21:18 BST JobSetup
 cet::exception caught in art
 ---- Configuration BEGIN
-  
-  
+
+
   Module label: source
   module_type : EmptyEvent
-  
+
   Any parameters prefaced with '#' are optional.
   Unsupported parameters:
-  
+
    + maxEvent                       [ /home/physics/phsdbc/sandbox/com.github/SuperNEMO-DBD/Impressionist.build/fcl/examples/second_error.fcl:14 ]
-  
+
 ---- Configuration END
 %MSG
 Art has completed and will exit with status 9.
@@ -552,9 +552,9 @@ $
 ```
 
 We can also define the filename in the FHiCL file using the
-`outputs` table. Note the plural as unlike `source` we can, if we wish, 
-have multiple output modules (for example, selected/rejected event samples). 
-However, because `outputs` is part of processing because of this we must also add 
+`outputs` table. Note the plural as unlike `source` we can, if we wish,
+have multiple output modules (for example, selected/rejected event samples).
+However, because `outputs` is part of processing because of this we must also add
 the `physics` table so we can declare the use of the output module:
 
 ```
@@ -581,8 +581,8 @@ order, and configuration parameters are defined. In `physics` we've added
 a FHiCL list `op` to define the modules to be processed, in this case the
 `myOutput` module we define later in the `outputs` table.
 The name `op` is arbitrary and can be anything you like, as Art's syntax
-can separate these lists from other settings as we'll see later. 
-This seemingly odd way of defining things will help later on when we define 
+can separate these lists from other settings as we'll see later.
+This seemingly odd way of defining things will help later on when we define
 more complex processing paths and multiple outputs.
 The script can be run like the others:
 
@@ -757,14 +757,14 @@ $ art --print-description EventIDFilter
 
            ## The 'idsToMatch' parameter value is a sequence of patterns,
            ## each of which are composed three fields:
-           ## 
+           ##
            ##   <run>:<subrun>:<event>
-           ## 
+           ##
            ## Each of the run, subrun, and event fields can be represented
            ## by a number, or set of numbers.  The '*' wildcard can be used to
            ## represent any number, and the ',' and '-' characters can be used
            ## to sets or ranges of numbers.  For example:
-           ## 
+           ##
            ##    "1:*:*"     // Accept Run 1, any SubRun, any Event
            ##    "1:2:*"     // Accept Run 1, SubRun 2, any Event
            ##    "1:2:3"     // Accept Run 1, SubRun 2, Event 3
@@ -772,7 +772,7 @@ $ art --print-description EventIDFilter
            ##    "1:2-5:*"   // Accept Run 1, SubRuns 2 through 5 (inclusive), any Event
            ##    "*:9:10,11" // Accept any Run, SubRun 9, Events 10 and 11
            ##    "7:2-5,8:*" // Accept Run 7, SubRuns 2 through 5 (inclusive) and 8, any Event
-           ## 
+           ##
            ## Specifying multiple patterns in the sequence corresponds to a
            ## logical OR of the patterns.  In other words, if the event in question
            ## matches any (not all) of the patterns, the event is accepted.
@@ -932,7 +932,7 @@ As noted above, FHiCL scripts are _composable_ from a set of smaller scripts. Th
 is implemented in the same way as C/C++ headers, so effectively FHiCL scripts can "#include" others,
 using the `FHICL_FILE_PATH` just like the header search path of a compiler.
 
-The exact syntax of this feature is discussed in Section 9 of the [FHiCL Quickstart Guide](https://cdcvs.fnal.gov/redmine/documents/327). To illustrate the simplest use, we can reproduce 
+The exact syntax of this feature is discussed in Section 9 of the [FHiCL Quickstart Guide](https://cdcvs.fnal.gov/redmine/documents/327). To illustrate the simplest use, we can reproduce
 the behaviour of the `third.fcl` script via including it in a new, one line script:
 
 ```
@@ -1077,7 +1077,7 @@ Failed to parse the configuration file 'examples/ninth.fcl' with exception
     "source.maxEvents" is protected on line 14 of file "<path>/examples/ninth.fcl"
   ---- Protection violation END
    at line 32, character 1, of file "<path>/examples/ninth.fcl"
-  
+
   source.maxEvents: 75
   ^
 ---- Parse error END
@@ -1088,3 +1088,12 @@ $
 
 Art is helpful here in telling us why the error occurred, together with
 the file and line numbers related to it.
+
+Using Art for SuperNEMO
+=======================
+
+The preceeding examples cover the general concepts of scripting data flow
+with art using its builtin functionality and FHiCL. SuperNEMO naturally
+requires additional code to describe its data and processing models, and
+these are covered in [the next document](ImpresssionistArt.md).
+

--- a/fcl/snemo/examples/sdanalyzer_t.fcl
+++ b/fcl/snemo/examples/sdanalyzer_t.fcl
@@ -1,0 +1,25 @@
+source: {
+  module_type : BrioInput
+}
+
+physics: {
+  # Analyzers have their own table
+  analyzers: {
+    myanalyzer: {
+      module_type: ExSDAnalyzer
+    }
+  }
+
+  # Analyzers go in an End Path
+  outputPath: [ myanalyzer ]
+}
+
+# Must declare the TFileService to enable it
+services: {
+  TFileService: {
+    # Write all output from any analyzer module here
+    fileName: "SDAnalyzerTest.root"
+  }
+}
+
+

--- a/snemo/CMakeLists.txt
+++ b/snemo/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(edm)
 add_subdirectory(test)

--- a/snemo/CMakeLists.txt
+++ b/snemo/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(edm)
+add_subdirectory(examples)
 add_subdirectory(test)

--- a/snemo/edm/BrioInput_source.cc
+++ b/snemo/edm/BrioInput_source.cc
@@ -1,0 +1,222 @@
+/// Example input source, see:
+/// https://cdcvs.fnal.gov/redmine/projects/art/wiki/Writing_your_own_input_sources
+/// for further details
+
+#include "art/Framework/Core/InputSourceMacros.h"
+#include "art/Framework/IO/Sources/Source.h"
+#include "art/Framework/IO/Sources/SourceTraits.h"
+#include "art/Framework/IO/Sources/put_product_in_principal.h"
+
+// Falaise/Bayeux
+#include "bayeux/brio/reader.h"
+#include "bayeux/datatools/things.h"
+#include "bayeux/mctools/simulated_data.h"
+
+#include "snemo/edm/GenBBPrimaryEvent.h"
+#include "snemo/edm/MultiProperties.h"
+#include "snemo/edm/StepHitCollection.h"
+#include "snemo/edm/event_header.h"
+
+// Forward declare implementation of input source
+namespace snemo {
+  class BrioInputSourceDriver;
+}
+
+class snemo::BrioInputSourceDriver {
+public:
+  // Required constructor
+  BrioInputSourceDriver(fhicl::ParameterSet const&,
+                        art::ProductRegistryHelper&,
+                        art::SourceHelper const&);
+
+  // Required member function
+  void readFile(std::string const& filename, art::FileBlock*& fb);
+
+  // Required member function
+  bool readNext(art::RunPrincipal const* const inR,
+                art::SubRunPrincipal const* const inSR,
+                art::RunPrincipal*& outR,
+                art::SubRunPrincipal*& outSR,
+                art::EventPrincipal*& outE);
+
+  // Required member function
+  void closeCurrentFile();
+
+private:
+  // Return true if the supplied reader has required stores
+  bool validateSchema(const brio::reader& r) const;
+
+private:
+  art::SourceHelper const&
+    srcHelper_;         ///< {Run,SubRun,Event}Principal construction helper
+  brio::reader bInput_; ///< Reader for BRIO files
+  std::string const GI_STORE{"GI"};
+  std::string const ER_STORE{"ER"};
+  std::set<std::string> const stepHitCategories{"gg", "calo", "xcalo", "gveto"};
+  std::string const outputLabel{"SD"}; ///< Matches expectation
+};
+
+// Implementation of the driver
+snemo::BrioInputSourceDriver::BrioInputSourceDriver(
+  fhicl::ParameterSet const& /*ps*/,
+  art::ProductRegistryHelper& helper,
+  art::SourceHelper const& aSH)
+  : srcHelper_{aSH}, bInput_{}
+{
+  // Products this source will reconstitute into Principals
+  // string is the module label.
+  // At the Run level, we add:
+  // 1. metadata on...
+  // At the Event level, we add:
+  helper.reconstitutes<snemo::MultiProperties, art::InRun>(outputLabel);
+  // 1. Primary vertex:
+  helper.reconstitutes<geomtools::vector_3d, art::InEvent>(outputLabel);
+  // 2. Time (always null in SD)
+  helper.reconstitutes<double, art::InEvent>(outputLabel);
+  // 3. Primary event
+  helper.reconstitutes<snemo::GenBBPrimaryEvent, art::InEvent>(outputLabel);
+  // each expected bank of hits, even if empty
+  for (auto hitCat : stepHitCategories) {
+    helper.reconstitutes<snemo::StepHitCollection, art::InEvent>(outputLabel,
+                                                                 hitCat);
+  }
+}
+
+void
+snemo::BrioInputSourceDriver::readFile(std::string const& filename,
+                                       art::FileBlock*& fb)
+{
+  bInput_.open(filename);
+  std::cout << "Opening file " << filename << std::endl;
+  if (!this->validateSchema(bInput_)) {
+    // Need to throw if we get here
+    // "throw cet::CodedException("BrioInput")"?
+  };
+
+  // Create the file block for the new file
+  fb =
+    new art::FileBlock{art::FileFormatVersion{1, "FLSIMULATE 3.3"}, filename};
+}
+
+bool
+snemo::BrioInputSourceDriver::readNext(art::RunPrincipal const* const inR,
+                                       art::SubRunPrincipal const* const inSR,
+                                       art::RunPrincipal*& outR,
+                                       art::SubRunPrincipal*& outSR,
+                                       art::EventPrincipal*& outE)
+{
+  // BRIO is based on while/next iteration...
+  // However, we seem to lose one event per file currently...
+  if (!bInput_.has_next(ER_STORE)) {
+    return false;
+  }
+
+  // If input RunPrincipal is null, we need to create one (we are not yet
+  // checking for boundaries, don't expect them in Brio files)
+  if (inR == nullptr) {
+    std::cout << "New run\n";
+    outR = srcHelper_.makeRunPrincipal(1, art::Timestamp{});
+    // GI_STORE likely has run level info, maybe even global (where it would be
+    // handled in open/close file and Service attachment)
+    // From Simulation, each element in the GI store
+    // has keys that tell us about it
+    // __dpp.io.metadata.key: the eventual key we need to look up
+    // __dpp.io.metadata.meta: the multiproperties "meta" key
+    // __dpp.io.metadata.rank: seems to just be the store index?
+    // These are used to reconstitute the overall multiproperties object
+    // Should be put in Run, then services can register to be notified
+    // of new Runs (hence new data)
+    datatools::properties p;
+    size_t entry{0};
+    auto inputMP = std::make_unique<snemo::MultiProperties>();
+
+    while (bInput_.has_next(GI_STORE)) {
+      bInput_.load(p, GI_STORE, entry);
+      std::string key{p.fetch_string("__dpp.io.metadata.key")};
+      std::string meta{p.fetch_string("__dpp.io.metadata.meta")};
+      p.clean("__dpp.io.metadata.key");
+      p.clean("__dpp.io.metadata.meta");
+      p.clean("__dpp.io.metadata.rank");
+      inputMP->add(key, meta, p);
+      ++entry;
+    }
+
+    art::put_product_in_principal(std::move(inputMP), *outR, outputLabel);
+  }
+  // Same for input SubRunPrincipal, need to create, but BRIO files have no
+  // concept of subrun so we simply match Run ID
+  if (inSR == nullptr) {
+    art::SubRunID srID{outR ? outR->run() : inR->run(), 0};
+    outSR = srcHelper_.makeSubRunPrincipal(
+      srID.run(), srID.subRun(), art::Timestamp{});
+  }
+
+  // ALWAYS create outE...
+  datatools::things e;
+  bInput_.load_next(e, ER_STORE);
+  // ER_STORE expected to hold two banks
+  // "EH" is a simple header. We only really need the event number for
+  // now.
+  auto EH = e.get<snemo::datamodel::event_header>("EH");
+  auto eID = EH.get_id().get_event_number();
+  outE = srcHelper_.makeEventPrincipal(outR ? outR->run() : inR->run(),
+                                       outSR ? outSR->subRun() : inSR->subRun(),
+                                       eID,
+                                       art::Timestamp{});
+
+  // "SD" is the simulated data itself, and has substructure that we convert:
+  auto SD = e.get<mctools::simulated_data>("SD");
+  // 1. Vertex (CLHEP 3vector)
+  auto vertex = std::make_unique<geomtools::vector_3d>(SD.get_vertex());
+  art::put_product_in_principal(std::move(vertex), *outE, outputLabel);
+
+  // 2. Time (double, though generally always zero for sim)
+  art::put_product_in_principal(
+    std::make_unique<double>(SD.get_time()), *outE, outputLabel);
+
+  // 3. Primary Event (genbb_primary event)
+  auto primary =
+    std::make_unique<snemo::GenBBPrimaryEvent>(SD.get_primary_event());
+  art::put_product_in_principal(std::move(primary), *outE, outputLabel);
+
+  // 4. Properties (but always empty)
+  // 5. Step hits (generally always collections of "handles":
+  //    - In this case, banks may be:
+  //      - calo
+  //      - xcalo
+  //      - gveto
+  //      - gg
+  for (auto hitCat : stepHitCategories) {
+    auto HC = std::make_unique<snemo::StepHitCollection>();
+
+    if (SD.has_step_hits(hitCat)) {
+      auto stepHits = SD.get_step_hits(hitCat);
+      HC->reserve(stepHits.size());
+      for (const auto& hitHandle : stepHits) {
+        HC->push_back(snemo::StepHit(hitHandle.get()));
+      }
+    }
+    art::put_product_in_principal(std::move(HC), *outE, outputLabel, hitCat);
+  }
+
+  return true;
+}
+
+void
+snemo::BrioInputSourceDriver::closeCurrentFile()
+{
+  bInput_.close();
+}
+
+bool
+snemo::BrioInputSourceDriver::validateSchema(const brio::reader& /*r*/) const
+{
+  return true;
+}
+
+// Make the implementation usable in the framework
+namespace snemo {
+  using BrioInputSource = art::Source<BrioInputSourceDriver>;
+}
+
+DEFINE_ART_INPUT_SOURCE(snemo::BrioInputSource)

--- a/snemo/edm/CMakeLists.txt
+++ b/snemo/edm/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(snemo_edm
   PUBLIC
     Bayeux::Bayeux
     Boost::serialization
+    ROOT::Core
   )
 
 # Create the Art dictionary so we can store Bayeux types directly
@@ -23,3 +24,6 @@ target_link_libraries(snemo_edm
 include_directories(${Bayeux_INCLUDE_DIRS})
 art_dictionary(DICTIONARY_LIBRARIES Bayeux::Bayeux)
 
+
+# Now the module
+simple_plugin(BrioInput "source" Bayeux::Bayeux snemo_edm)

--- a/snemo/edm/CMakeLists.txt
+++ b/snemo/edm/CMakeLists.txt
@@ -1,0 +1,25 @@
+add_library(snemo_edm SHARED
+  event_header.h
+  event_header.ipp
+  event_header.cc
+  timestamp.h
+  timestamp.ipp
+  timestamp.cc
+  bayeux_dict.cc
+  )
+target_include_directories(snemo_edm
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+  )
+target_link_libraries(snemo_edm
+  PUBLIC
+    Bayeux::Bayeux
+    Boost::serialization
+  )
+
+# Create the Art dictionary so we can store Bayeux types directly
+# in ROOT (likely also need ROOT_INCLUDE_DIRS at runtime to avoid
+# "Cling autoload" issues.
+include_directories(${Bayeux_INCLUDE_DIRS})
+art_dictionary(DICTIONARY_LIBRARIES Bayeux::Bayeux)
+

--- a/snemo/edm/CalorimeterHit.h
+++ b/snemo/edm/CalorimeterHit.h
@@ -1,0 +1,24 @@
+#ifndef CALORIMETERHIT_HH
+#define CALORIMETERHIT_HH
+
+/// Rough Model of a calibrated calorimeter hit
+
+#include "bayeux/geomtools/geom_id.h"
+
+namespace snemo {
+
+  struct CalorimeterHit {
+    // Info
+    size_t hitID;
+    geomtools::geom_id geoID;
+
+    // Data
+    double energy;
+    double energyError;
+    double time;
+    double timeError;
+  };
+
+} // namespace snemo
+
+#endif // CALORIMETERHIT_HH

--- a/snemo/edm/CalorimeterHitCollection.h
+++ b/snemo/edm/CalorimeterHitCollection.h
@@ -1,0 +1,13 @@
+#ifndef CALORIMETERHITCOLLECTION_HH
+#define CALORIMETERHITCOLLECTION_HH
+
+/// Rough model of a collection of Calorimeter Hits
+
+#include "snemo/edm/CalorimeterHit.h"
+#include <vector>
+
+namespace snemo {
+  using CalorimeterHitCollection = std::vector<CalorimeterHit>;
+} // namespace snemo
+
+#endif // CALORIMETERHITCOLLECTION_HH

--- a/snemo/edm/GeigerHit.h
+++ b/snemo/edm/GeigerHit.h
@@ -1,0 +1,23 @@
+#ifndef GEIGERHIT_HH
+#define GEIGERHIT_HH
+
+/// Rough model of a calibrated Geiger hit
+#include "bayeux/geomtools/geom_id.h"
+#include <cstdint>
+
+namespace snemo {
+  struct GeigerHit {
+    uint32_t flags;
+    double radius;
+    double radiusError;
+    double z;
+    double zError;
+    double x;
+    double y;
+    double delayedTime;
+    double delayedTimeError;
+    geomtools::geom_id geoId;
+  };
+} // namespace snemo
+
+#endif // GEIGERHIT_HH

--- a/snemo/edm/GeigerHitCollection.h
+++ b/snemo/edm/GeigerHitCollection.h
@@ -1,0 +1,12 @@
+#ifndef GEIGERHITCOLLECTION_HH
+#define GEIGERHITCOLLECTION_HH
+
+/// Rough model of collection of Geiger hits
+#include "snemo/edm/GeigerHit.h"
+#include <vector>
+
+namespace snemo {
+  using GeigerHitCollection = std::vector<GeigerHit>;
+} // namespace snemo
+
+#endif // GEIGERHITCOLLECTION_HH

--- a/snemo/edm/GenBBPrimaryEvent.h
+++ b/snemo/edm/GenBBPrimaryEvent.h
@@ -12,7 +12,8 @@ namespace snemo {
   public:
     GenBBPrimaryEvent() = default;
     virtual ~GenBBPrimaryEvent(){};
-    GenBBPrimaryEvent(const genbb::primary_event& p) : genbb::primary_event(p) {}
+    GenBBPrimaryEvent(const genbb::primary_event& p) : genbb::primary_event(p)
+    {}
   };
 } // namespace snemo
 

--- a/snemo/edm/GenBBPrimaryEvent.h
+++ b/snemo/edm/GenBBPrimaryEvent.h
@@ -1,0 +1,19 @@
+#ifndef GENBBPRIMARYEVENT_HH
+#define GENBBPRIMARYEVENT_HH
+
+// Art's products cannot have underscores in the friendly
+// name. Workaround this for Bayeux's genbb::primary_event
+// type by direct inheritance.
+
+#include "bayeux/genbb_help/primary_event.h"
+
+namespace snemo {
+  class GenBBPrimaryEvent : public genbb::primary_event {
+  public:
+    GenBBPrimaryEvent() = default;
+    virtual ~GenBBPrimaryEvent(){};
+    GenBBPrimaryEvent(const genbb::primary_event& p) : genbb::primary_event(p) {}
+  };
+} // namespace snemo
+
+#endif // GENBBPRIMARYEVENT_HH

--- a/snemo/edm/MultiProperties.h
+++ b/snemo/edm/MultiProperties.h
@@ -12,7 +12,9 @@ namespace snemo {
   public:
     MultiProperties() = default;
     virtual ~MultiProperties(){};
-    MultiProperties(const datatools::multi_properties& p) : datatools::multi_properties(p) {}
+    MultiProperties(const datatools::multi_properties& p)
+      : datatools::multi_properties(p)
+    {}
   };
 } // namespace snemo
 

--- a/snemo/edm/MultiProperties.h
+++ b/snemo/edm/MultiProperties.h
@@ -1,0 +1,19 @@
+#ifndef SNEMO_MULTI_PROPERTIES_HH
+#define SNEMO_MULTI_PROPERTIES_HH
+
+// Art's products cannot have underscores in the friendly
+// name. Workaround this for Bayeux's datatools::multi_properties
+// type by direct inheritance.
+
+#include "bayeux/datatools/multi_properties.h"
+
+namespace snemo {
+  class MultiProperties : public datatools::multi_properties {
+  public:
+    MultiProperties() = default;
+    virtual ~MultiProperties(){};
+    MultiProperties(const datatools::multi_properties& p) : datatools::multi_properties(p) {}
+  };
+} // namespace snemo
+
+#endif // SNEMO_MULTI_PROPERTIES_HH

--- a/snemo/edm/README.md
+++ b/snemo/edm/README.md
@@ -1,0 +1,29 @@
+Reading Falaise/FLSimulate Output Data into Art
+===============================================
+FLSimulate outputs its data into "BRIO" format files. These are ROOT
+files which put data into a set of TTrees (or "stores" in BRIO-speak).
+Each TTree has a single branch that stores an opaque buffer
+whose content is a binary stream of data for the stored type as
+serialized by the Bayeux+Boost serialization system.
+
+FLSimulate writes two stores:
+
+- "GI" (**G**eneral **I**nformation)
+  - Stored type: [`datatools::properties`](https://supernemo.org/Bayeux/classdatatools_1_1properties.html)
+  - Number of entries: free
+  - Intended that each entry is reconstituted and added to a [`datatools::multi_properties`](https://supernemo.org/Bayeux/classdatatools_1_1multi__properties.html) instance
+  - Data in this instance describes the simulation setup
+    - Exact entries to be documented...
+- "ER" (**E**vent **R**ecord)
+  - Stored type: [`datatools::things`](https://supernemo.org/Bayeux/classdatatools_1_1properties.html)
+  - Number of entries: same as number generated
+  - `datatools::things` maps a string identifier to a data product instance, and as output by `flsimulate` holds two products:
+    - "EH": an instance of [`datatools::event_header`]()
+    - "SD": an instance of [`mctools::simulated_data`]()
+      - In turn, this holds:
+        - An instance of [`geomtools::vector_3d`]() for the truth vertex
+        - An instance of [`genbb::primary_event`]() for the truth primary particles
+        - Collections of [`mctools::step_hits`]() for each of the tracker, main calorimeter, xwall calorimeter, and muon veto
+
+
+

--- a/snemo/edm/StepHit.h
+++ b/snemo/edm/StepHit.h
@@ -1,0 +1,20 @@
+#ifndef STEP_HIT_HH
+#define STEP_HIT_HH
+
+// Art's products cannot have underscores in the friendly
+// name. Workaround this for Bayeux's mctools::base_step_hit
+// type by direct inheritance.
+
+#include "bayeux/mctools/base_step_hit.h"
+
+namespace snemo {
+  class BaseStepHit : public mctools::base_step_hit {
+  public:
+    BaseStepHit() = default;
+    virtual ~BaseStepHit(){};
+    BaseStepHit(const mctools::base_step_hit& p) : mctools::base_step_hit(p) {}
+  };
+  using StepHit = BaseStepHit;
+} // namespace snemo
+
+#endif // STEP_HIT_HH

--- a/snemo/edm/StepHitCollection.h
+++ b/snemo/edm/StepHitCollection.h
@@ -1,0 +1,11 @@
+#ifndef STEP_HIT_COLLECTION_HH
+#define STEP_HIT_COLLECTION_HH
+
+#include "snemo/edm/StepHit.h"
+#include <vector>
+
+namespace snemo {
+  using StepHitCollection = std::vector<StepHit>;
+} // namespace snemo
+
+#endif // STEP_HIT_COLLECTION_HH

--- a/snemo/edm/bayeux_dict.cc
+++ b/snemo/edm/bayeux_dict.cc
@@ -28,12 +28,14 @@
 #endif
 
 #include "timestamp.ipp"
-DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::timestamp)
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(
+  snemo::datamodel::timestamp)
 
 /**********************************
  * snemo::datamodel::event_header *
  **********************************/
 
 #include "event_header.ipp"
-DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::event_header)
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(
+  snemo::datamodel::event_header)
 BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::event_header)

--- a/snemo/edm/bayeux_dict.cc
+++ b/snemo/edm/bayeux_dict.cc
@@ -1,0 +1,39 @@
+// Third party:
+// - Boost:
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
+#include <boost/serialization/export.hpp>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+// - Bayeux/datatools:
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
+#include <datatools/archives_instantiation.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#include "timestamp.ipp"
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::timestamp)
+
+/**********************************
+ * snemo::datamodel::event_header *
+ **********************************/
+
+#include "event_header.ipp"
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::event_header)
+BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::event_header)

--- a/snemo/edm/classes.h
+++ b/snemo/edm/classes.h
@@ -1,0 +1,24 @@
+#include "canvas/Persistency/Common/Wrapper.h"
+
+// Need to include entire inheritance chain
+#include "bayeux/datatools/i_clear.h"
+#include "bayeux/datatools/i_serializable.h"
+#include "bayeux/datatools/i_tree_dump.h"
+
+#include "bayeux/datatools/event_id.h"
+#include "bayeux/datatools/properties.h"
+#include "bayeux/geomtools/geom_id.h"
+
+// Datatools workarounds
+#include "snemo/edm/MultiProperties.h"
+
+// MC
+#include "snemo/edm/GenBBPrimaryEvent.h"
+#include "snemo/edm/StepHit.h"
+#include "snemo/edm/StepHitCollection.h"
+
+// Processing
+#include "snemo/edm/CalorimeterHit.h"
+#include "snemo/edm/CalorimeterHitCollection.h"
+#include "snemo/edm/GeigerHit.h"
+#include "snemo/edm/GeigerHitCollection.h"

--- a/snemo/edm/classes_def.xml
+++ b/snemo/edm/classes_def.xml
@@ -1,0 +1,55 @@
+<!--  Include art::Wrapper lines for objects that we would like to put  -->
+<!--  into art::Event -->
+<!--  Include the non-wrapper lines for all objects on the art::Wrapper -->
+<!--  lines and for all objects that are data members of those objects.-->
+<!--  See https://cdcvs.fnal.gov/redmine/projects/art/wiki/Data_Product_Dictionary_How-To -->
+
+<lcgdict>
+  <class name="datatools::i_serializable" classVersion="10"/>
+  <class name="datatools::i_tree_dumpable" classVersion="10"/>
+  <class name="datatools::i_clear" classVersion="10"/>
+  <class name="datatools::i_cloneable" classVersion="10"/>
+
+  <class name="datatools::event_id" classVersion="10"/>
+
+  <!-- Properties: low->high -->
+  <class name="datatools::properties::data" classVersion="10"/>
+  <class name="std::map<std::string, datatools::properties::data>"/>
+  <class name="datatools::properties" classVersion="10">
+    <field name="_key_validator_" transient="true"/>
+  </class>
+  <class name="art::Wrapper<datatools::properties>"/>
+
+  <!-- Multi_Properties: low->high -->
+  <class name="datatools::multi_properties::entry" classVersion="10"/>
+  <class name="std::map<std::string, datatools::multi_properties::entry>" classVersion="10"/>
+  <class name="std::list<datatools::multi_properties::entry*>" classVersion="10"/>
+  <class name="datatools::multi_properties" classVersion="10"/>
+  <class name="snemo::MultiProperties" classVersion="10"/>
+  <class name="art::Wrapper<snemo::MultiProperties>"/>
+
+  <!-- MCTools types: low->high -->
+  <class name="geomtools::geom_id" classVersion="10"/>
+  <class name="geomtools::base_hit" classVersion="10"/>
+  <class name="mctools::base_step_hit" classVersion="10"/>
+
+  <class name="snemo::StepHit" classVersion="10"/>
+  <class name="snemo::StepHitCollection" classVersion="10"/>
+  <class name="art::Wrapper<snemo::StepHitCollection>"/>
+
+  <!-- GenBB types -->
+  <class name="genbb::primary_particle" classVersion="10"/>
+  <class name="std::list<genbb::primary_particle>" classVersion="10"/>
+  <class name="genbb::primary_event" classVersion="10"/>
+
+  <class name="snemo::GenBBPrimaryEvent" classVersion="10"/>
+  <class name="art::Wrapper<snemo::GenBBPrimaryEvent>"/>
+
+  <!-- Reconstruction level types -->
+  <class name="snemo::CalorimeterHit" classVersion="10"/>
+  <class name="snemo::CalorimeterHitCollection" classVersion="10"/>
+  <class name="art::Wrapper<snemo::CalorimeterHitCollection>" classVersion="10"/>
+  <class name="snemo::GeigerHit" classVersion="10"/>
+  <class name="snemo::GeigerHitCollection" classVersion="10"/>
+  <class name="art::Wrapper<snemo::GeigerHitCollection>" classVersion="10"/>
+</lcgdict>

--- a/snemo/edm/event_header.cc
+++ b/snemo/edm/event_header.cc
@@ -1,0 +1,169 @@
+/// \file falaise/snemo/datamodels/event_header.cc
+
+// Ourselves:
+#include "snemo/edm/event_header.h"
+
+namespace snemo {
+
+  namespace datamodel {
+
+    // Serial tag for datatools::i_serializable interface :
+    DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(event_header,
+                                                      "snemo::datamodel::event_header")
+
+    // static
+    const std::string&
+    event_header::event_header_label()
+    {
+      static const std::string _label("EH");
+      return _label;
+    }
+
+    event_header::event_header() { _generation_ = GENERATION_INVALID; }
+
+    event_header::~event_header() {}
+
+    const datatools::event_id&
+    event_header::get_id() const
+    {
+      return _id_;
+    }
+
+    datatools::event_id&
+    event_header::grab_id()
+    {
+      return _id_;
+    }
+
+    void
+    event_header::set_id(const datatools::event_id& id_)
+    {
+      _id_ = id_;
+    }
+
+    const datatools::properties&
+    event_header::get_properties() const
+    {
+      return _properties_;
+    }
+
+    datatools::properties&
+    event_header::grab_properties()
+    {
+      return _properties_;
+    }
+
+    void
+    event_header::set_properties(const datatools::properties& properties_)
+    {
+      _properties_ = properties_;
+    }
+
+    const snemo::datamodel::timestamp&
+    event_header::get_timestamp() const
+    {
+      return _timestamp_;
+    }
+
+    snemo::datamodel::timestamp&
+    event_header::grab_timestamp()
+    {
+      return _timestamp_;
+    }
+
+    void
+    event_header::set_timestamp(const snemo::datamodel::timestamp& timestamp_)
+    {
+      _timestamp_ = timestamp_;
+    }
+
+    event_header::generation_type
+    event_header::get_generation() const
+    {
+      return _generation_;
+    }
+
+    void
+    event_header::set_generation(generation_type generation_)
+    {
+      _generation_ = generation_;
+    }
+
+    bool
+    event_header::is_real() const
+    {
+      return _generation_ == GENERATION_REAL;
+    }
+
+    bool
+    event_header::is_simulated() const
+    {
+      return _generation_ == GENERATION_SIMULATED;
+    }
+
+    void
+    event_header::clear()
+    {
+      _properties_.clear();
+      _timestamp_.invalidate();
+      _generation_ = GENERATION_INVALID;
+      _id_.clear();
+    }
+
+    void
+    event_header::tree_dump(std::ostream& out_,
+                            const std::string& title_,
+                            const std::string& indent_,
+                            bool inherit_) const
+    {
+      std::string indent;
+      if (!indent_.empty()) {
+        indent = indent_;
+      }
+      if (!title_.empty()) {
+        out_ << indent << title_ << std::endl;
+      }
+
+      out_ << indent << datatools::i_tree_dumpable::tag << "Id : " << std::endl;
+      {
+        std::ostringstream indent_oss;
+        indent_oss << indent;
+        indent_oss << datatools::i_tree_dumpable::skip_tag;
+        _id_.tree_dump(out_, "", indent_oss.str());
+      }
+
+      out_ << indent << datatools::i_tree_dumpable::tag << "Timestamp : " << _timestamp_
+           << std::endl;
+
+      out_ << indent << datatools::i_tree_dumpable::tag << "Properties : ";
+      if (_properties_.size() == 0) {
+        out_ << "<empty>";
+      }
+      out_ << std::endl;
+      {
+        std::ostringstream indent_oss;
+        indent_oss << indent;
+        indent_oss << datatools::i_tree_dumpable::skip_tag;
+        _properties_.tree_dump(out_, "", indent_oss.str());
+      }
+
+      out_ << indent << datatools::i_tree_dumpable::inherit_tag(inherit_)
+           << "Generation : " << _generation_;
+      if (is_simulated()) {
+        out_ << ' ' << "[simulated]";
+      }
+      if (is_real()) {
+        out_ << ' ' << "[real]";
+      }
+      out_ << std::endl;
+    }
+
+    void
+    event_header::dump() const
+    {
+      tree_dump(std::clog, event_header::SERIAL_TAG);
+    }
+
+  } // end of namespace datamodel
+
+} // end of namespace snemo

--- a/snemo/edm/event_header.cc
+++ b/snemo/edm/event_header.cc
@@ -8,8 +8,9 @@ namespace snemo {
   namespace datamodel {
 
     // Serial tag for datatools::i_serializable interface :
-    DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(event_header,
-                                                      "snemo::datamodel::event_header")
+    DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(
+      event_header,
+      "snemo::datamodel::event_header")
 
     // static
     const std::string&
@@ -132,8 +133,8 @@ namespace snemo {
         _id_.tree_dump(out_, "", indent_oss.str());
       }
 
-      out_ << indent << datatools::i_tree_dumpable::tag << "Timestamp : " << _timestamp_
-           << std::endl;
+      out_ << indent << datatools::i_tree_dumpable::tag
+           << "Timestamp : " << _timestamp_ << std::endl;
 
       out_ << indent << datatools::i_tree_dumpable::tag << "Properties : ";
       if (_properties_.size() == 0) {

--- a/snemo/edm/event_header.h
+++ b/snemo/edm/event_header.h
@@ -1,0 +1,128 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/event_header.h
+/* Author (s) :   Francois Mauger <mauger@lpccaen.in2p3.fr>
+ * Creation date: 2010-11-07
+ * Last modified: 2014-01-27
+ *
+ * License:
+ *
+ * Description:
+ *
+ *   Event header
+ *
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODEL_EVENT_HEADER_H
+#define FALAISE_SNEMO_DATAMODEL_EVENT_HEADER_H 1
+
+// Third party:
+// - Boost :
+#include <boost/cstdint.hpp>
+#include <boost/serialization/access.hpp>
+// - Bayeux/datatools :
+#include <datatools/event_id.h>
+#include <datatools/i_clear.h>
+#include <datatools/i_serializable.h>
+#include <datatools/i_tree_dump.h>
+#include <datatools/properties.h>
+
+// This project:
+#include "snemo/edm/timestamp.h"
+
+namespace snemo {
+
+  namespace datamodel {
+
+    /// \brief A event header class to be embedded as a bank in a 'datatools::things' event record.
+    class event_header : public datatools::i_serializable,
+                         public datatools::i_clear,
+                         public datatools::i_tree_dumpable {
+    public:
+      /// \brief Generation type of the event record
+      enum generation_type {
+        GENERATION_INVALID = -1, ///< Invalid generation type
+        GENERATION_REAL = 0,     ///< Real event from the detector's DAQ
+        GENERATION_SIMULATED = 1 ///< Simulated event from the MC application
+      };
+
+      /// Return the default label/name of a 'event header' bank
+      static const std::string& event_header_label();
+
+      /// Constructor
+      event_header();
+
+      /// Destructor
+      virtual ~event_header();
+
+      /// Return the event ID
+      const datatools::event_id& get_id() const;
+
+      /// Return the mutable event ID
+      datatools::event_id& grab_id();
+
+      /// Set the event ID
+      void set_id(const datatools::event_id&);
+
+      /// Return the constant list of properties
+      const datatools::properties& get_properties() const;
+
+      /// Return the mutable list of properties
+      datatools::properties& grab_properties();
+
+      /// Set the list of properties
+      void set_properties(const datatools::properties&);
+
+      /// Return the timestamp
+      const snemo::datamodel::timestamp& get_timestamp() const;
+
+      /// Return the mutable timestamp
+      snemo::datamodel::timestamp& grab_timestamp();
+
+      /// Set the timestamp
+      void set_timestamp(const snemo::datamodel::timestamp&);
+
+      /// Return the generation
+      generation_type get_generation() const;
+
+      /// Set the generation
+      void set_generation(generation_type);
+
+      /// Check if event record is real (collected by the experiment DAQ)
+      bool is_real() const;
+
+      /// Check if event record is simulated
+      bool is_simulated() const;
+
+      /// Clear the event header internal data
+      virtual void clear();
+
+      /// Smart print
+      virtual void tree_dump(std::ostream& out_ = std::clog,
+                             const std::string& title_ = "",
+                             const std::string& indent_ = "",
+                             bool inherit_ = false) const;
+
+      /// Basic print
+      void dump() const;
+
+    private:
+      datatools::event_id _id_;                //!< Run/Event ID
+      generation_type _generation_;            //!< Generation flag
+      snemo::datamodel::timestamp _timestamp_; //!< Reference time of the event
+      datatools::properties _properties_;      //!< Dictionary of properties
+
+      DATATOOLS_SERIALIZATION_DECLARATION()
+    };
+
+  } // end of namespace datamodel
+
+} // end of namespace snemo
+
+#include <boost/serialization/export.hpp>
+BOOST_CLASS_EXPORT_KEY2(snemo::datamodel::event_header, "snemo::datamodel::event_header")
+
+// Class version:
+#include <boost/serialization/version.hpp>
+BOOST_CLASS_VERSION(snemo::datamodel::event_header, 1)
+
+#endif // FALAISE_SNEMO_DATAMODEL_EVENT_HEADER_H

--- a/snemo/edm/event_header.h
+++ b/snemo/edm/event_header.h
@@ -33,7 +33,8 @@ namespace snemo {
 
   namespace datamodel {
 
-    /// \brief A event header class to be embedded as a bank in a 'datatools::things' event record.
+    /// \brief A event header class to be embedded as a bank in a
+    /// 'datatools::things' event record.
     class event_header : public datatools::i_serializable,
                          public datatools::i_clear,
                          public datatools::i_tree_dumpable {
@@ -119,7 +120,8 @@ namespace snemo {
 } // end of namespace snemo
 
 #include <boost/serialization/export.hpp>
-BOOST_CLASS_EXPORT_KEY2(snemo::datamodel::event_header, "snemo::datamodel::event_header")
+BOOST_CLASS_EXPORT_KEY2(snemo::datamodel::event_header,
+                        "snemo::datamodel::event_header")
 
 // Class version:
 #include <boost/serialization/version.hpp>

--- a/snemo/edm/event_header.ipp
+++ b/snemo/edm/event_header.ipp
@@ -1,0 +1,43 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/event_header.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_EVENT_HEADER_IPP
+#define FALAISE_SNEMO_DATAMODEL_EVENT_HEADER_IPP 1
+
+// Ourselves:
+#include "snemo/edm/event_header.h"
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+// - Bayeux/datatools:
+#include <datatools/event_id.ipp>
+#include <datatools/i_serializable.ipp>
+#include <datatools/properties.ipp>
+
+// This project:
+#include "snemo/edm/timestamp.ipp"
+
+namespace snemo {
+
+  namespace datamodel {
+
+    template <class Archive>
+    void
+    event_header::serialize(Archive& ar_, const unsigned int version_)
+    {
+      if (version_ > 0) {
+        ar_& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
+      }
+      ar_& boost::serialization::make_nvp("id", _id_);
+      ar_& boost::serialization::make_nvp("generation", _generation_);
+      ar_& boost::serialization::make_nvp("timestamp", _timestamp_);
+      ar_& boost::serialization::make_nvp("properties", _properties_);
+    }
+
+  } // end of namespace datamodel
+
+} // end of namespace snemo
+
+#endif // FALAISE_SNEMO_DATAMODEL_EVENT_HEADER_IPP

--- a/snemo/edm/timestamp.cc
+++ b/snemo/edm/timestamp.cc
@@ -16,10 +16,14 @@ namespace snemo {
   namespace datamodel {
 
     // serial tag for datatools::i_serializable interface :
-    DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(timestamp, "snemo::datamodel::timestamp")
+    DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(
+      timestamp,
+      "snemo::datamodel::timestamp")
 
-    const int64_t timestamp::INVALID_SECONDS = std::numeric_limits<int64_t>::min();
-    const int64_t timestamp::INVALID_PICOSECONDS = std::numeric_limits<int64_t>::min();
+    const int64_t timestamp::INVALID_SECONDS =
+      std::numeric_limits<int64_t>::min();
+    const int64_t timestamp::INVALID_PICOSECONDS =
+      std::numeric_limits<int64_t>::min();
 
     const char timestamp::IO_FORMAT_OPEN = '[';
     const char timestamp::IO_FORMAT_SEP = ':';
@@ -40,7 +44,8 @@ namespace snemo {
     bool
     timestamp::is_valid() const
     {
-      return _seconds_ != INVALID_SECONDS && _picoseconds_ != INVALID_PICOSECONDS;
+      return _seconds_ != INVALID_SECONDS &&
+             _picoseconds_ != INVALID_PICOSECONDS;
     }
 
     void
@@ -54,7 +59,8 @@ namespace snemo {
     timestamp::compare(const timestamp& ts_) const
     {
       DT_THROW_IF(!is_valid(), std::logic_error, "Invalid timestamp (this) !");
-      DT_THROW_IF(!ts_.is_valid(), std::logic_error, "Invalid timestamp (argument) !");
+      DT_THROW_IF(
+        !ts_.is_valid(), std::logic_error, "Invalid timestamp (argument) !");
       if (_seconds_ < ts_._seconds_)
         return -1;
       if (_seconds_ > ts_._seconds_)

--- a/snemo/edm/timestamp.cc
+++ b/snemo/edm/timestamp.cc
@@ -1,0 +1,232 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/timestamp.cc
+
+// Ourselves:
+#include "snemo/edm/timestamp.h"
+
+// Standard library:
+#include <limits>
+
+// Third party:
+// - Bayeux:
+#include <bayeux/datatools/clhep_units.h>
+
+namespace snemo {
+
+  namespace datamodel {
+
+    // serial tag for datatools::i_serializable interface :
+    DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(timestamp, "snemo::datamodel::timestamp")
+
+    const int64_t timestamp::INVALID_SECONDS = std::numeric_limits<int64_t>::min();
+    const int64_t timestamp::INVALID_PICOSECONDS = std::numeric_limits<int64_t>::min();
+
+    const char timestamp::IO_FORMAT_OPEN = '[';
+    const char timestamp::IO_FORMAT_SEP = ':';
+    const char timestamp::IO_FORMAT_CLOSE = ']';
+    const char timestamp::IO_FORMAT_INVALID = '?';
+
+    timestamp::timestamp() { invalidate(); }
+
+    timestamp::timestamp(int64_t sec_, int64_t picosec_)
+    {
+      set_seconds(sec_);
+      set_picoseconds(picosec_);
+    }
+
+    // dtor:
+    timestamp::~timestamp() { return; }
+
+    bool
+    timestamp::is_valid() const
+    {
+      return _seconds_ != INVALID_SECONDS && _picoseconds_ != INVALID_PICOSECONDS;
+    }
+
+    void
+    timestamp::invalidate()
+    {
+      _seconds_ = INVALID_SECONDS;
+      _picoseconds_ = INVALID_PICOSECONDS;
+    }
+
+    int
+    timestamp::compare(const timestamp& ts_) const
+    {
+      DT_THROW_IF(!is_valid(), std::logic_error, "Invalid timestamp (this) !");
+      DT_THROW_IF(!ts_.is_valid(), std::logic_error, "Invalid timestamp (argument) !");
+      if (_seconds_ < ts_._seconds_)
+        return -1;
+      if (_seconds_ > ts_._seconds_)
+        return +1;
+      if (_picoseconds_ < ts_._picoseconds_)
+        return -1;
+      if (_picoseconds_ > ts_._picoseconds_)
+        return +1;
+      return 0;
+    }
+
+    int64_t
+    timestamp::get_seconds() const
+    {
+      return _seconds_;
+    }
+
+    void
+    timestamp::set_seconds(int64_t new_value_)
+    {
+      _seconds_ = new_value_;
+    }
+
+    int64_t
+    timestamp::get_picoseconds() const
+    {
+      return _picoseconds_;
+    }
+
+    void
+    timestamp::set_picoseconds(int64_t new_value_)
+    {
+      _picoseconds_ = new_value_;
+    }
+
+    double
+    timestamp::to_real() const
+    {
+      double time = _seconds_ * CLHEP::second;
+      time += _picoseconds_ * CLHEP::picosecond;
+      return time;
+    }
+
+    bool
+    operator==(const timestamp& ts1_, const timestamp& ts2_)
+    {
+      return ts1_.compare(ts2_) == 0;
+    }
+
+    bool
+    operator<(const timestamp& ts1_, const timestamp& ts2_)
+    {
+      return ts1_.compare(ts2_) == -1;
+    }
+
+    bool
+    operator>(const timestamp& ts1_, const timestamp& ts2_)
+    {
+      return ts1_.compare(ts2_) == +1;
+    }
+
+    bool
+    operator<=(const timestamp& ts1_, const timestamp& ts2_)
+    {
+      return ts1_.compare(ts2_) <= 0;
+    }
+
+    bool
+    operator>=(const timestamp& ts1_, const timestamp& ts2_)
+    {
+      return ts1_.compare(ts2_) >= 0;
+    }
+
+    void
+    timestamp::to_string(std::string& str_) const
+    {
+      std::ostringstream out;
+      out << *this;
+      str_ = out.str();
+      return;
+    }
+
+    std::string
+    timestamp::to_string() const
+    {
+      std::ostringstream out;
+      out << *this;
+      return out.str();
+    }
+
+    void
+    timestamp::from_string(const std::string& str_)
+    {
+      timestamp ts;
+      std::istringstream in(str_);
+      in >> ts;
+      DT_THROW_IF(!in, std::logic_error, "Format error !");
+      *this = ts;
+      return;
+    }
+
+    std::ostream&
+    operator<<(std::ostream& out_, const timestamp& ts_)
+    {
+      out_ << timestamp::IO_FORMAT_OPEN;
+      if (ts_._seconds_ != timestamp::INVALID_SECONDS) {
+        out_ << ts_._seconds_;
+      } else {
+        out_ << timestamp::IO_FORMAT_INVALID;
+      }
+      out_ << timestamp::IO_FORMAT_SEP;
+      if (ts_._picoseconds_ != timestamp::INVALID_PICOSECONDS) {
+        out_ << ts_._picoseconds_;
+      } else {
+        out_ << timestamp::IO_FORMAT_INVALID;
+      }
+      out_ << timestamp::IO_FORMAT_CLOSE;
+      return out_;
+    }
+
+    std::istream&
+    operator>>(std::istream& a_in, timestamp& ts_)
+    {
+      char c = 0;
+      a_in >> c;
+      if (!a_in)
+        return a_in;
+      if (c != timestamp::IO_FORMAT_OPEN) {
+        a_in.setstate(std::ios_base::failbit);
+        return a_in;
+      }
+      int64_t s, ps;
+      c = 0;
+
+      c = a_in.peek();
+      if (c == timestamp::IO_FORMAT_INVALID) {
+        s = timestamp::INVALID_SECONDS;
+        a_in.get();
+      } else {
+        a_in >> s;
+        if (!a_in)
+          return a_in;
+      }
+
+      c = 0;
+      a_in >> c;
+      if (c != timestamp::IO_FORMAT_SEP) {
+        a_in.setstate(std::ios_base::failbit);
+        return a_in;
+      }
+
+      c = a_in.peek();
+      if (c == timestamp::IO_FORMAT_INVALID) {
+        ps = timestamp::INVALID_SECONDS;
+        a_in.get();
+      } else {
+        a_in >> ps;
+        if (!a_in)
+          return a_in;
+      }
+
+      c = 0;
+      a_in >> c;
+      if (c != timestamp::IO_FORMAT_CLOSE) {
+        a_in.setstate(std::ios_base::failbit);
+        return a_in;
+      }
+      ts_.set_seconds(s);
+      ts_.set_picoseconds(ps);
+      return a_in;
+    }
+
+  } // end of namespace datamodel
+
+} // end of namespace snemo

--- a/snemo/edm/timestamp.h
+++ b/snemo/edm/timestamp.h
@@ -1,0 +1,105 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/timestamp.h
+/* Author(s) :    Francois Mauger <mauger@lpccaen.in2p3.fr>
+ * Creation date: 2010-03-15
+ * Last modified: 2014-01-27
+ *
+ * License:
+ *
+ * Description:
+ *
+ *   High resolution timestamp
+ *
+ * History:
+ *
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODELS_TIMESTAMP_H
+#define FALAISE_SNEMO_DATAMODELS_TIMESTAMP_H 1
+
+// Third party:
+// - Boost:
+#include <boost/cstdint.hpp>
+#include <boost/serialization/access.hpp>
+// - Bayeux/datatools :
+#include <bayeux/datatools/i_serializable.h>
+
+namespace snemo {
+
+  namespace datamodel {
+
+    /// \brief A class to handle time stamp
+    class timestamp : public datatools::i_serializable {
+    public:
+      static const int64_t INVALID_SECONDS;
+      static const int64_t INVALID_PICOSECONDS;
+      static const char IO_FORMAT_OPEN;
+      static const char IO_FORMAT_SEP;
+      static const char IO_FORMAT_CLOSE;
+      static const char IO_FORMAT_INVALID;
+
+      /// Constructor
+      timestamp();
+
+      /// Overloaded constructor
+      timestamp(int64_t sec_, int64_t picosec_);
+
+      /// Destructor
+      virtual ~timestamp();
+
+      /// Return the number of seconds
+      int64_t get_seconds() const;
+
+      /// Set the number of seconds
+      void set_seconds(int64_t);
+
+      /// Return the number of picoseconds
+      int64_t get_picoseconds() const;
+
+      /// Set the number of picoseconds
+      void set_picoseconds(int64_t);
+
+      /// Check if the timestamp object is valid
+      bool is_valid() const;
+
+      /// Invalidate the timestamp object
+      void invalidate();
+
+      /// Compare with another timestamp
+      int compare(const timestamp&) const;
+
+      /// Convert timestamp to real value (explicit time unit)
+      double to_real() const;
+
+      /// Format time stamp as string object and return it
+      std::string to_string() const;
+
+      /// Format time stamp as string object and return it as reference
+      void to_string(std::string&) const;
+
+      /// Parse time from string object and set the timestamp object accordingly
+      void from_string(const std::string&);
+
+      friend bool operator==(const timestamp&, const timestamp&);
+      friend bool operator<(const timestamp&, const timestamp&);
+      friend bool operator>(const timestamp&, const timestamp&);
+      friend bool operator<=(const timestamp&, const timestamp&);
+      friend bool operator>=(const timestamp&, const timestamp&);
+      friend std::ostream& operator<<(std::ostream&, const timestamp&);
+      friend std::istream& operator>>(std::istream&, timestamp&);
+
+    private:
+      int64_t _seconds_;     //!< Number of seconds
+      int64_t _picoseconds_; //!< Number of picoseconds
+
+      DATATOOLS_SERIALIZATION_DECLARATION()
+    };
+
+  } // end of namespace datamodel
+
+} // end of namespace snemo
+
+#include <boost/serialization/version.hpp>
+BOOST_CLASS_VERSION(snemo::datamodel::timestamp, 1)
+
+#endif // FALAISE_SNEMO_DATAMODELS_TIMESTAMP_H

--- a/snemo/edm/timestamp.ipp
+++ b/snemo/edm/timestamp.ipp
@@ -1,0 +1,35 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datatmodels/timestamp.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TIMESTAMP_IPP
+#define FALAISE_SNEMO_DATAMODEL_TIMESTAMP_IPP 1
+
+// Ourselves:
+#include "snemo/edm/timestamp.h"
+
+// Third party:
+// - Boost:
+#include <boost/serialization/nvp.hpp>
+// - Bayeux/datatools:
+#include <datatools/i_serializable.ipp>
+
+namespace snemo {
+
+  namespace datamodel {
+
+    template <class Archive>
+    void
+    timestamp::serialize(Archive& ar_, const unsigned int version_)
+    {
+      if (version_ > 0) {
+        ar_& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
+      }
+      ar_& boost::serialization::make_nvp("seconds", _seconds_);
+      ar_& boost::serialization::make_nvp("picoseconds", _picoseconds_);
+    }
+
+  } // end of namespace datamodel
+
+} // end of namespace snemo
+
+#endif // FALAISE_SNEMO_DATAMODEL_TIMESTAMP_IPP

--- a/snemo/examples/CMakeLists.txt
+++ b/snemo/examples/CMakeLists.txt
@@ -1,0 +1,7 @@
+simple_plugin(ExSDAnalyzer "module"
+  art_root_io_TFileService_service
+  art_root_io_tfile_support
+  art_Framework_Services_Registry
+  ${ROOT_HIST}
+  snemo_edm
+  )

--- a/snemo/examples/ExSDAnalyzer_module.cc
+++ b/snemo/examples/ExSDAnalyzer_module.cc
@@ -1,0 +1,101 @@
+//! \file SDAnalyzer_module.cc
+//! \brief Demo analyzer module with use of TFileService
+//!
+//! Largely adapted from art_root_io/test/TestTFileService_module.cc
+//! It demonstrates the minimum needed to extract a data product and
+//! use TFileService to product plots for per-Event data with recommended
+//! multithreading setup (see also "Multithreaded processing" on the art wiki:
+//! https://cdcvs.fnal.gov/redmine/projects/art/wiki
+//!
+
+#include "TH1.h"
+#include "snemo/edm/StepHitCollection.h"
+
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Core/SharedAnalyzer.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art/Utilities/SharedResource.h"
+#include "art_root_io/TFileService.h"
+#include "fhiclcpp/ParameterSet.h"
+#include <string>
+
+namespace snemo {
+
+  class SDAnalyzer : public art::SharedAnalyzer {
+  public:
+    explicit SDAnalyzer(fhicl::ParameterSet const& p,
+                        art::ProcessingFrame const& frame);
+
+  private:
+    // Main method we must implement
+    void analyze(art::Event const& e, art::ProcessingFrame const& frame);
+
+    // Where the Root objects will be created from the TFileService,
+    // also used as callback when TFileService switches files
+    void initRootObjects();
+
+    // Primary Input Tag roughly equivalent to "bank label" in dpp
+    art::InputTag const sdBankLabel;
+
+    // Token for data product we'll use. Helps art to validate that
+    // we don't use data that hasn't been produced yet
+    art::ProductToken<StepHitCollection> const ggHitsToken;
+
+    // Can hold normal Root pointers. Will be created/owned by the
+    // TFileService
+    TH1F* geigerHitCounter{nullptr};
+  };
+
+  SDAnalyzer::SDAnalyzer(fhicl::ParameterSet const& p,
+                         art::ProcessingFrame const& frame)
+    : art::SharedAnalyzer{p}
+      // Label hard coded, but can be parameter
+    , sdBankLabel{"SD"}
+    ,
+    // Use consumes to mark what we consume
+    ggHitsToken{consumes<StepHitCollection>({sdBankLabel.label(), "gg"})}
+  {
+    // Must serialize access to the TFileService
+    serialize(art::SharedResource<art::TFileService>);
+
+    // Get the service from the frame, and register a callback
+    // for the file switch transition
+    auto const fs = frame.serviceHandle<art::TFileService>();
+    fs->registerFileSwitchCallback(this, &SDAnalyzer::initRootObjects);
+
+    // Create our Root Objects
+    initRootObjects();
+  }
+
+  void
+  SDAnalyzer::initRootObjects()
+  {
+    // get the service
+    art::ServiceHandle<art::TFileService> fs;
+
+    // All Root objects for *this* module are created
+    // by default in a TDirectory whose name matches
+    // the module label in the FHiCL script.
+
+    // Through we only have one product, show we can create
+    // additional subdirectories if required:
+    art::TFileDirectory geigerDir = fs->mkdir("geiger");
+
+    // Create histo in that directory
+    geigerHitCounter = geigerDir.make<TH1F>(
+      "geiger_step_counter", "Number of Geiger Steps per Event", 100, 0., 100.);
+  }
+
+  void
+  SDAnalyzer::analyze(art::Event const& e, art::ProcessingFrame const&)
+  {
+    // Extract the GeigerHC via its token
+    auto const& ghc = e.getValidHandle(ggHitsToken);
+
+    // Fill the histo
+    geigerHitCounter->Fill(ghc->size());
+  }
+
+} // namespace snemo
+
+DEFINE_ART_MODULE(snemo::SDAnalyzer)

--- a/ups/setup_for_development
+++ b/ups/setup_for_development
@@ -80,6 +80,13 @@ test "${exit_now}" = "true" && return 1
 
 # add lib to LD_LIBRARY_PATH
 source $CETBUILDTOOLS_DIR/bin/set_dev_lib
+
+# ADDED BY IMPRESSIONIST
+# - Make sure ROOT can find "products" built via ExternalProject
+setenv ROOT_INCLUDE_PATH ${CETPKG_BUILD}/IMPExternals/include:${CETPKG_BUILD}/IMPExternals/include/bayeux:${ROOT_INCLUDE_PATH}
+setenv LD_LIBRARY_PATH ${CETPKG_BUILD}/IMPExternals/lib:${LD_LIBRARY_PATH}
+# ------
+
 # add bin to path
 source $CETBUILDTOOLS_DIR/bin/set_dev_bin
 # set FHICL_FILE_PATH


### PR DESCRIPTION
This enables Art to read BRIO files and data output by `flsimulate`. Existing Bayeux data products such as `properties` are adapted to Art's required naming conventions. The minimum set of Falaise data products are imported directly from the main repository. A standard library and ROOT dictionary are built.

Reading of BRIO into Art is implemented as a custom source module. FLSimulate's "GI" metadata store is reconstituted into the Run Principal, and "ER" store into the Event Principal. The "ER" store's hierarchical structure is flattened so that each relevant product can be accessed directly (to be demonstrated)

Begin documentation of use of module/data products and their implementation details.

TODO: Implement and document Analyzer module to demonstrate C++ access to data products.

Addresses #2 